### PR TITLE
Version Update - otel-java-agent (Mar 2026)

### DIFF
--- a/.github/ISSUE_TEMPLATE/version-update---otel-java-agent.md
+++ b/.github/ISSUE_TEMPLATE/version-update---otel-java-agent.md
@@ -2,7 +2,7 @@
 name: Version Update - otel-java-agent
 about: update otel-java-agent version
 title: Version Update - otel-java-agent (Month Year)
-labels: image
+labels: image, monitoring
 assignees: DavGeoAnd
 
 ---

--- a/.github/workflows/otel-java-agent.yml
+++ b/.github/workflows/otel-java-agent.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Push the Docker image
         run: |
-          bash docker_image.sh $REPOSITORY prod ${{ steps.lookupJavaVersion.outputs.result }} ${{ steps.lookupOtelVersion.outputs.result }}
+          bash image_management.sh $REPOSITORY prod ${{ steps.lookupJavaVersion.outputs.result }} ${{ steps.lookupOtelVersion.outputs.result }}

--- a/image_management.sh
+++ b/image_management.sh
@@ -28,19 +28,24 @@ otel-collector-service() {
   fi
 }
 
+downloadOtelJavaAgent() {
+    wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v"${OTEL_JAVA_AGENT_VERSION}"/opentelemetry-javaagent.jar -P ./otel-java-agent
+}
+
 otel-java-agent() {
   JAVA_VERSION=${3:-$(yq '.java.version' ./otel-java-agent/version.yaml)}
   OTEL_JAVA_AGENT_VERSION=${4:-$(yq '.otel-java-agent.version' ./otel-java-agent/version.yaml)}
   echo "java.version: $JAVA_VERSION"
   echo "otel-java-agent.version: $OTEL_JAVA_AGENT_VERSION"
   echo "env: $env"
-  wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v"${OTEL_JAVA_AGENT_VERSION}"/opentelemetry-javaagent.jar -P ./otel-java-agent
 
   if [ "${env}" == "local" ]; then
-    docker build --no-cache -t local/otel-java-agent:latest --build-arg java_version="${JAVA_VERSION}" ./otel-java-agent/
+    downloadOtelJavaAgent
+    docker build --no-cache -t "local/otel-java-agent:$JAVA_VERSION-$OTEL_JAVA_AGENT_VERSION" --build-arg java_version="${JAVA_VERSION}" ./otel-java-agent/
     rm ./otel-java-agent/opentelemetry-javaagent.jar
 
   elif [ "${env}" == "prod" ]; then
+    downloadOtelJavaAgent
     docker build --no-cache -t "$REGISTRY/$REPOSITORY:$JAVA_VERSION-$OTEL_JAVA_AGENT_VERSION" --build-arg java_version="${JAVA_VERSION}" ./otel-java-agent/
     docker image push -a "$REGISTRY/$REPOSITORY"
 

--- a/otel-java-agent/version.yaml
+++ b/otel-java-agent/version.yaml
@@ -1,4 +1,4 @@
 java:
   version: 21.0.9_10
 otel-java-agent:
-  version: 2.21.0
+  version: 2.26.0


### PR DESCRIPTION
- changed script name and pulled download otel java agent to separate function
- update script name in GitHub action workout
- update otel java agent to 2.26.0
- update otel java agent template to include monitoring label