### PR TITLE
OTEL Version Update (June 2026)

### DIFF
--- a/.github/ISSUE_TEMPLATE/OTEL Collector Service Version Update.md
+++ b/.github/ISSUE_TEMPLATE/OTEL Collector Service Version Update.md
@@ -1,0 +1,12 @@
+---
+name: OTEL Collector Service Version Update
+about: update version for OTEL collector service image
+title: OTEL Collector Service Version Update (Month Year)
+labels: aws, image, monitoring
+assignees: DavGeoAnd
+
+---
+
+- otel-collector-service
+    - update version
+        - otel-collector-contrib: update with the latest version from https://github.com/open-telemetry/opentelemetry-collector-contrib/releases

--- a/.github/ISSUE_TEMPLATE/OTEL Java Agent Version Update.md
+++ b/.github/ISSUE_TEMPLATE/OTEL Java Agent Version Update.md
@@ -1,15 +1,12 @@
 ---
-name: OTEL Version Update
-about: update version for OTEL images
-title: OTEL Version Update (Month Year)
+name: OTEL Java Agent Version Update
+about: update version for OTEL java agent image
+title: OTEL Java Agent Version Update (Month Year)
 labels: aws, image, monitoring
 assignees: DavGeoAnd
 
 ---
 
-- otel-collector-api
-    - update version
-        - otel-collector-contrib: update with the latest version from https://github.com/open-telemetry/opentelemetry-collector-contrib/releases
 - otel-java-agent
     - update version
         - java: update if the version use to code with has changed

--- a/.github/workflows/otel-java-agent.yml
+++ b/.github/workflows/otel-java-agent.yml
@@ -12,7 +12,7 @@ on:
       - otel-java-agent/version.yaml
 
 env:
-  REGISTRY: davgeoand9
+  REGISTRY: davidgandalcio
   REPOSITORY: otel-java-agent
 
 jobs:
@@ -29,8 +29,8 @@ jobs:
         with:
           cmd: yq '.java.version' 'otel-java-agent/version.yaml'
 
-      - name: Get otel version
-        id: lookupOtelVersion
+      - name: Get otel java agent version
+        id: lookupOtelJavaAgentVersion
         uses: mikefarah/yq@master
         with:
           cmd: yq '.otel-java-agent.version' 'otel-java-agent/version.yaml'
@@ -41,4 +41,4 @@ jobs:
 
       - name: Push the Docker image
         run: |
-          bash otel-java-agent/docker_build.sh prod ${{ steps.lookupJavaVersion.outputs.result }} ${{ steps.lookupOtelVersion.outputs.result }}
+          bash otel-java-agent/docker_build.sh prod ${{ steps.lookupJavaVersion.outputs.result }} ${{ steps.lookupOtelJavaAgentVersion.outputs.result }}

--- a/otel-java-agent/Dockerfile
+++ b/otel-java-agent/Dockerfile
@@ -7,9 +7,11 @@ COPY opentelemetry-javaagent.jar /otel-agent/opentelemetry-javaagent.jar
 ENV JAVA_TOOL_OPTIONS='-javaagent:/otel-agent/opentelemetry-javaagent.jar'
 
 # otel general
+ENV OTEL_INSTRUMENTATION_MICROMETER_ENABLED=true
 
 # otel metrics
 ENV OTEL_METRICS_EXPORTER=none
+ENV OTEL_METRIC_EXPORT_INTERVAL=20000
 
 # otel logs
 ENV OTEL_LOGS_EXPORTER=none

--- a/otel-java-agent/version.yaml
+++ b/otel-java-agent/version.yaml
@@ -1,4 +1,6 @@
+#https://hub.docker.com/_/eclipse-temurin
 java:
-  version: 21.0.9_10
+  version: 21.0.11_10
+#https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
 otel-java-agent:
   version: 2.28.1


### PR DESCRIPTION
- enable micrometer by default
- export metrics every 20s
- update docker registry
- update java version
- separate otel version update