### PR TITLE
OTEL Java Agent Version Update (July 2026)

### DIFF
--- a/otel-java-agent/Dockerfile
+++ b/otel-java-agent/Dockerfile
@@ -1,6 +1,6 @@
 ARG java_version=latest
 
-FROM eclipse-temurin:${java_version}-jre-noble
+FROM eclipse-temurin:${java_version}-jre-ubi10-minimal
 
 COPY opentelemetry-javaagent.jar /otel-agent/opentelemetry-javaagent.jar
 

--- a/otel-java-agent/version.yaml
+++ b/otel-java-agent/version.yaml
@@ -1,6 +1,6 @@
 #https://hub.docker.com/_/eclipse-temurin
 java:
-  version: 21.0.11_10
+  version: 25.0.3_9
 #https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
 otel-java-agent:
-  version: 2.28.1
+  version: 2.29.0


### PR DESCRIPTION
- move to redhat image
- update java and otel agent versions